### PR TITLE
chore(ci): bump GH Actions off Node 20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up JDK 25
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '25'
         distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       tag: ${{ steps.parse.outputs.tag }}
     steps:
       - name: Checkout (with full history for rev-list)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Parse version
@@ -119,8 +119,8 @@ jobs:
             mvn_prefix: ''
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -149,7 +149,7 @@ jobs:
             rm -rf "Strange Eons"
           fi
       - name: Upload installers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: deployment/installers/*
@@ -161,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all installer artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
       - name: Rename to canonical asset names

--- a/.github/workflows/synch-tags.yml
+++ b/.github/workflows/synch-tags.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create same tag on doc repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary

Quiets the Node 20 deprecation warnings on Actions by bumping every action to its current major (all using Node 24):

- `actions/checkout@v4` → `@v6`
- `actions/setup-java@v4` → `@v5`
- `actions/upload-artifact@v4` → `@v7`
- `actions/download-artifact@v4` → `@v8`
- `actions/github-script@v7` → `@v9`

## Notes on breaking changes

Reviewed release notes for the larger jumps:

- **`upload-artifact@v7`** adds an optional `archive: false` parameter for direct (unzipped) single-file uploads. We don't use it; existing `path: deployment/installers/*` glob still uploads zipped as before.
- **`download-artifact@v8`** migrates to ESM (transparent), enforces hash checks by default, and adds optional `skip-decompress`. We don't override any of those; safer-by-default is fine.

The tag-pushed `Release` workflow exercises every bumped action, so the next real release will validate the chain end-to-end. CI will exercise checkout/setup-java on this PR.

## Test plan

- [x] CI passes on this PR
- [ ] Next tag push runs Release workflow successfully (artifacts upload + GH release create)