### PR TITLE
Friendlier message when an .eon file is corrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@
   the original direct-reflection path and pre-install hook ordering.
   `Theme.modifyLookAndFeelDefaults` / `modifyLookAndFeel` Javadoc was
   updated to describe the per-path timing.
+- Friendlier failure when an `.eon` file is corrupt or truncated
+  (issue #5, alpha-tester report). `ResourceKit.getGameComponentFromStream`
+  now catches `EOFException` / `OptionalDataException` separately from
+  the generic `Exception` bucket and surfaces a localized
+  "the file appears to be corrupt or incomplete" dialog (new
+  `app-err-corrupt` resource key) instead of a raw Java stack trace.
+  Stack trace stays in the log at INFO. Existing magic-bytes and
+  generic-error paths are unchanged. Also lowered
+  `ImagePreviewer.LoaderThread`'s catch-all from INFO to FINE so
+  best-effort thumbnail-preview failures don't pollute the default
+  log.
 
 ## 2026-04-29
 

--- a/src/main/java/ca/cgjennings/ui/fcpreview/ImagePreviewer.java
+++ b/src/main/java/ca/cgjennings/ui/fcpreview/ImagePreviewer.java
@@ -117,7 +117,7 @@ public class ImagePreviewer extends JPanel {
             try {
                 temp = createPreviewImage(f);
             } catch (Throwable t) {
-                StrangeEons.log.log(Level.INFO, "previewer could not load image: " + f, t);
+                StrangeEons.log.log(Level.FINE, "previewer could not load image: " + f, t);
             }
             if (temp != null && !Thread.interrupted()) {
                 final BufferedImage tn = temp;

--- a/src/main/java/resources/ResourceKit.java
+++ b/src/main/java/resources/ResourceKit.java
@@ -70,6 +70,7 @@ import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;
 import java.awt.print.PrinterJob;
 import java.io.BufferedReader;
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -77,6 +78,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OptionalDataException;
 import java.io.StreamCorruptedException;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
@@ -2629,6 +2631,12 @@ public class ResourceKit {
             StrangeEons.log.log(Level.SEVERE, string("app-err-badmagic", sourceDescription), e);
             if (reportError) {
                 displayError(string("app-err-badmagic", sourceDescription), null);
+            }
+            return null;
+        } catch (EOFException | OptionalDataException e) {
+            StrangeEons.log.log(Level.INFO, "corrupt component file: " + sourceDescription, e);
+            if (reportError) {
+                displayError(string("app-err-corrupt", sourceDescription), null);
             }
             return null;
         } catch (Exception e) {

--- a/src/main/resources/resources/text/interface/eons-text.properties
+++ b/src/main/resources/resources/text/interface/eons-text.properties
@@ -245,6 +245,8 @@ app-err-outofmem-hasmax = Close some files and retry, or run Strange Eons again 
        (This would allow Strange Eons to use up to 2 GiB of memory.)
 app-err-open = Unable to open %s
 app-err-badmagic = This does not appear to be a Strange Eons file
+app-err-corrupt = Strange Eons can't open %s because the file appears to be corrupt or incomplete.<br>\
+       If you have a backup copy (an older version, a sync-service version history, or Time Machine on macOS), try opening that instead.
 app-err-uncaught = Uncaught exception while starting the application
 
 app-warn-proj-minver = This project states that it requires\n\


### PR DESCRIPTION
ResourceKit.getGameComponentFromStream now distinguishes truncation / shape-mismatch (EOFException, OptionalDataException) from the generic Exception bucket and surfaces a localized "file appears to be corrupt or incomplete" dialog instead of a raw stack trace. Closes #5.