### PR TITLE
perf(scripting): cache style-literal evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## 2026-04-30
 
+- Memoized `Settings.textStyle` `{...}` literal evaluation. Each
+  literal previously constructed a fresh `ScriptMonkey` (full
+  `SEScriptEngine` + bootstrap) just to evaluate a small expression
+  like `{ResourceKit.bodyFamily}`. Telemetry on a 12-component AHLCG
+  deck open showed 5403 calls to only 73 distinct source strings
+  (98.6% hit rate) and zero `Scriptable` results — every result was a
+  plain Java value (`String`, `Double`, `Float`). Caching the result
+  by source text is sound: only non-`Scriptable` results land in the
+  cache, so a `NativeObject` (which would carry a parent-scope
+  reference and re-introduce the issue #7 retention pattern) falls
+  through to the slow path. Combined with the compile cache:
+  - `ScriptMonkey` constructions per deck open: 5422 → **92** (59×).
+  - Total script evals: 38126 → **816** (47×).
+  - Style-literal-specific evals: 10806 → **146** (74×).
+  - Cumulative `ScriptMonkey` construction time: ~5400 ms → **293 ms**.
+  - JFR HashMap activity (downstream of slot-map churn): ~22% →
+    **<2%** of CPU samples.
+  - Hot CPU now dominated by `jj2000` JP2 image decode + Java2D
+    rendering — irreducible work for drawing card thumbnails.
+  - This is a tactical fix; the literal-evaluator path is removed
+    entirely in the planned JS-extraction project (phase 5.1).
 - Released per-DIY JavaScript engines on editor close (issue #14). After
   the issue #6 grace timer fix and the issue #7 retention sweep, the
   dominant remaining post-close retention was 10+ per-DIY Rhino engines

--- a/src/main/java/resources/Settings.java
+++ b/src/main/java/resources/Settings.java
@@ -2102,21 +2102,7 @@ public class Settings implements Serializable, Iterable<String> {
                     case '{':
                         isLiteral = true;
                         valueText = valueText.substring(1, valueText.length() - (end == '}' ? 1 : 0));
-                        // A fresh evaluator per call: caching it on a ThreadLocal
-                        // (the previous design) accumulated cross-engine scope
-                        // references in the evaluator's bindings, pinning per-DIY
-                        // ScriptMonkeys for the lifetime of the thread. Issue #7.
-                        // This whole literal-evaluator path is removed entirely
-                        // in the JS-extraction project (phase 5.1).
-                        ScriptMonkey evaluator = new ScriptMonkey("style setting literal");
-                        evaluator.eval(
-                            "importPackage(gamedata);"
-                            + "importPackage(resources);"
-                            + "importClass(java.awt.font.TextAttribute);"
-                            + "importClass(java.awt.font.TransformAttribute);"
-                            + "importClass(java.awt.geom.AffineTransform);"
-                        );
-                        value = evaluator.eval(valueText);
+                        value = evaluateStyleLiteral(valueText);
                         break;
                     case '\'':
                     case '"':
@@ -2202,6 +2188,47 @@ public class Settings implements Serializable, Iterable<String> {
         }
         return styleDesc.length();
     }
+
+    /**
+     * Evaluates a {@code {...}} style literal value, caching the result by
+     * source text. The previous design constructed a fresh {@link ScriptMonkey}
+     * per literal, which on a 12-component AHLCG deck open meant ~5400
+     * full-engine allocations to evaluate ~73 unique source strings
+     * (98.6% hit rate). Caching the result eliminates the per-literal
+     * engine churn while preserving the original semantics.
+     *
+     * <p>Only "safe" results — primitives, boxed wrappers, strings, and
+     * other plain Java objects — are cached. A Rhino {@code Scriptable}
+     * (e.g. a {@code NativeObject} from a JS object literal) carries a
+     * reference back to its parent scope and thus to the producing
+     * {@link ScriptMonkey}; caching one would re-introduce the issue #7
+     * retention pattern. Such results fall through to the slow path on
+     * every call. In practice no AHLCG-style literal returns a
+     * {@code Scriptable}.
+     */
+    private static Object evaluateStyleLiteral(String valueText) {
+        Object cached = STYLE_LITERAL_CACHE.get(valueText);
+        if (cached != null) {
+            return cached;
+        }
+        ScriptMonkey evaluator = new ScriptMonkey("style setting literal");
+        evaluator.eval(STYLE_LITERAL_IMPORTS);
+        Object result = evaluator.eval(valueText);
+        if (result != null && !(result instanceof org.mozilla.javascript.Scriptable)) {
+            STYLE_LITERAL_CACHE.put(valueText, result);
+        }
+        return result;
+    }
+
+    private static final java.util.concurrent.ConcurrentMap<String, Object> STYLE_LITERAL_CACHE
+            = new java.util.concurrent.ConcurrentHashMap<>();
+
+    private static final String STYLE_LITERAL_IMPORTS
+            = "importPackage(gamedata);"
+            + "importPackage(resources);"
+            + "importClass(java.awt.font.TextAttribute);"
+            + "importClass(java.awt.font.TransformAttribute);"
+            + "importClass(java.awt.geom.AffineTransform);";
 
     private static String cleanStyleKey(String key) {
         return key.toUpperCase(Locale.CANADA).replace(' ', '_');


### PR DESCRIPTION
## Summary

- Memoize `Settings.textStyle` `{...}` literal results by source text. Only non-`Scriptable` results are cached (preserves issue #7 retention safety).

## Stacked on #17

This PR targets `chore/script-engine-perf` (PR #17). Merge #17 first, then this; GitHub will auto-retarget to `main` after.

## Why

Telemetry on a 12-component AHLCG deck open: **5403 calls to only 73 distinct source strings (98.6% hit rate)**, every result a plain Java value (`String`/`Double`/`Float`). Constructing a fresh `ScriptMonkey` for each was the dominant remaining cost after the compile cache from #17. Top sources are property lookups like `Eons.namedObjects.AHLCGObject.storyFamily` repeated 309× — pure functional-result territory.

## Retention safety

A `NativeObject` (Rhino JS object literal) carries a `parentScope` reference back to its producing `ScriptMonkey`'s scope. Caching one would re-introduce the issue #7 retention pattern. The `instanceof Scriptable` filter on cache writes ensures only plain Java values land in the map; anything `Scriptable` falls through to the per-call slow path. AHLCG telemetry showed zero `Scriptable` results, so this is theoretical defense-in-depth — but cheap.

## Measured impact (AHLCG 12-component deck open)

| | After #17 alone | + this PR |
|---|---|---|
| ScriptMonkeys constructed | 5422 | **92** (59×) |
| Total script evals | 38126 | **816** (47×) |
| Style-literal evals | 10806 | **146** (74×) |
| Cumulative ScriptMonkey ctor | ~5400 ms | **293 ms** (18×) |
| JFR HashMap CPU | ~22% | **<2%** |
| `Method.copy()` allocations | 12.72% | not in top 20 |
| `JavaMembers.reflect` CPU | 6.99% | not in top 20 |

Top JFR hot spots are now `jj2000` JP2 image decode (~10%) and Java2D rendering — the actual cost of drawing card thumbnails. The script engine is no longer in the top 5.

## Test plan

- [x] `mvn test` passes.
- [x] Deck opens with no script errors; renders correctly.
- [x] User-felt: confirmed deck open feels markedly faster.
- [x] Manual heap-dump retention check — open deck, close all components, force GC, confirm no per-DIY `ScriptMonkey` is retained from style-literal eval. (The `Scriptable` filter is the structural guarantee; the heap dump is a verifier.)